### PR TITLE
[Fix] iOS 알림·위치 설정 및 마이페이지 주소 연동

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,6 +1,7 @@
 import Flutter
 import UIKit
 import GoogleMaps
+import UserNotifications
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
@@ -23,12 +24,23 @@ import GoogleMaps
             print("Failed to load .env file")
         }
     }
-    
+
     if !mapsApiKey.isEmpty {
         GMSServices.provideAPIKey(mapsApiKey)
     }
 
+    UNUserNotificationCenter.current().delegate = self
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  // 앱이 포그라운드 상태일 때도 알림 표시
+  override func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+  ) {
+    completionHandler([.banner, .sound, .badge])
   }
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {

--- a/lib/common/widgets/navigation_screen.dart
+++ b/lib/common/widgets/navigation_screen.dart
@@ -34,11 +34,7 @@ class _NavigationContent extends StatelessWidget {
     final viewModel = context.watch<MapViewModel>();
 
     return Scaffold(
-      // IndexedStack은 화면 전환 시 이전 상태를 보존해줍니다 (지도 위치 등)
-      body: IndexedStack(
-        index: viewModel.currentIndex,
-        children: _screens,
-      ),
+      body: _screens[viewModel.currentIndex],
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: viewModel.currentIndex,
         onTap: (index) => viewModel.changeTab(index),

--- a/lib/route/routes.dart
+++ b/lib/route/routes.dart
@@ -12,7 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
-final AppRouter = GoRouter(initialLocation: Paths.map, routes: [
+final AppRouter = GoRouter(initialLocation: Paths.login, routes: [
   GoRoute(
       path: Paths.login,
       pageBuilder: (context, state) => MaterialPage(

--- a/lib/screens/map/map_view_model.dart
+++ b/lib/screens/map/map_view_model.dart
@@ -58,6 +58,20 @@ class MapViewModel extends ChangeNotifier {
 
   Future<void> _initializeLocation() async {
     try {
+      // iOS에서 geolocator가 CLLocationManager 권한을 직접 확인/요청
+      LocationPermission permission = await Geolocator.checkPermission();
+      if (permission == LocationPermission.denied) {
+        permission = await Geolocator.requestPermission();
+      }
+      if (permission == LocationPermission.deniedForever) {
+        debugPrint('[MapViewModel] 위치 권한 영구 거부');
+        currentLocation = const LatLng(37.5665, 126.9780);
+        isLoading = false;
+        notifyListeners();
+        _startLocationStream();
+        return;
+      }
+
       final position = await Geolocator.getCurrentPosition(
           locationSettings:
               const LocationSettings(accuracy: LocationAccuracy.high));

--- a/lib/screens/mypage/mypage_view_model.dart
+++ b/lib/screens/mypage/mypage_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:ansim_app/data/repository/local/secure_storage_repository.dart';
 import 'package:ansim_app/data/service/user_service.dart';
 import 'package:ansim_app/screens/auth/auth_provider.dart';
 import 'package:flutter/material.dart';
@@ -5,6 +6,7 @@ import 'package:get_it/get_it.dart';
 
 class MyPageViewModel extends ChangeNotifier {
   final UserService _userService = UserService();
+  final SecureStorageRepository _secureStorage = SecureStorageRepository();
 
   bool _isLoading = true;
   String? _name;
@@ -42,7 +44,12 @@ class MyPageViewModel extends ChangeNotifier {
       _name = profile['name'] as String?;
       _email = profile['email'] as String?;
       _profileImage = profile['profileImage'] as String?;
-      _address = profile['address'] as String?;
+      final serverAddress = profile['address'] as String?;
+      if (serverAddress != null && serverAddress.isNotEmpty) {
+        _address = serverAddress;
+      } else {
+        _address = await _secureStorage.readUserAddress();
+      }
 
       final settings = profile['settings'] as Map<String, dynamic>?;
       if (settings != null) {


### PR DESCRIPTION
## Issue

- closes #

## Description

<!-- 무엇을 했는지 -->
- iOS 포그라운드 알림 수신                                                                                                                                                                                                                                                                                       
    - AppDelegate에 UNUserNotificationCenterDelegate 명시적 설정 및 willPresent 구현으로 앱 실행 중에도 알림 표시                                                                                                                                                                                                
  - iOS 위치 권한 수정                                                                                                                                                                                                                                                                                             
    - permission_handler만으로는 geolocator의 CLLocationManager가 권한을 인식 못하는 iOS 이슈 수정                                                                                                                                                                                                                 
    - _initializeLocation() 진입 시 Geolocator.checkPermission() / requestPermission() 추가                                                                                                                                                                                                                        
  - 바텀 네비게이션 탭 전환 시 화면 재빌드                                                                                                                                                                                                                                                                         
    - IndexedStack 제거 → _screens[currentIndex] 직접 렌더링으로 탭 전환 시마다 화면 dispose & rebuild                                                                                                                                                                                                             
  - 마이페이지 주소 자동 표시                                                                                                                                                                                                                                                                                      
    - 서버 프로필에 주소가 없을 경우 위도·경도 역지오코딩으로 저장된 SecureStorage 주소를 fallback으로 표시    

  ### Test plan                                                                                                                                                                                                                                                                                                        

  - iOS 실기기에서 앱 포그라운드 상태 중 근접 알림 수신 확인                                                                                                                                                                                                                                                       
  - iOS 첫 실행 시 위치 권한 요청 팝업 → 허용 후 지도에 현재 위치 정상 표시 확인                                                                                                                                                                                                                                 
  - 바텀 탭 전환 시 각 화면 재빌드(상태 초기화) 확인                                                                                                                                                                                                                                                               
                                                       

## Screenshot


## 💬 리뷰 요구사항(선택)
